### PR TITLE
Finish fixing the script

### DIFF
--- a/SCRIPT/C9-ATS2-install-latest.sh
+++ b/SCRIPT/C9-ATS2-install-latest.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/bash
 
 ######
 #
@@ -120,7 +120,7 @@ cp -f ATS2/utils/libatsopt/libatsopt.a ${ATSHOME}/ccomp/lib
 #
 (cd ATS2/utils/libatsynmark && make && make clean)
 #
-cp -f ATS2/utils/libatsynmark/libatsynmark.a ${ATSHOME}/ccomp/lib
+cp -f ATS2/utils/libatsynmark/BUILD/libatsynmark.a ${ATSHOME}/ccomp/lib
 #
 ######
 #


### PR DESCRIPTION
Forgot to make these changes in the script from the last commit: https://github.com/ats-lang/ats-lang.github.io/pull/9

Make the shell use `#!/usr/bin/bash` to prevent errors about `time` not found. _I think `#!/usr/bin/env sh` puts bash in compatibility mode so that is behaves as though it's not present._

Fix up the path to `libatsynmark.a`